### PR TITLE
depth image (REP 118 canonical) with image floating points, fixes #7

### DIFF
--- a/ensenso_camera/include/ensenso_camera/camera.h
+++ b/ensenso_camera/include/ensenso_camera/camera.h
@@ -131,6 +131,7 @@ private:
   image_transport::CameraPublisher leftRectifiedImagePublisher;
   image_transport::CameraPublisher rightRectifiedImagePublisher;
   image_transport::Publisher disparityMapPublisher;
+  image_transport::CameraPublisher depthImagePublisher;
 
   ros::Publisher pointCloudPublisher;
 

--- a/ensenso_camera/include/ensenso_camera/image_utilities.h
+++ b/ensenso_camera/include/ensenso_camera/image_utilities.h
@@ -29,3 +29,10 @@ std::vector<std::pair<sensor_msgs::ImagePtr, sensor_msgs::ImagePtr>> imagesFromN
  * Get the timestamp from an NxLib image node.
  */
 ros::Time timestampFromNxLibNode(NxLibItem const& node);
+
+/**
+ * Get the z-channel from the calculated point cloud and transform it
+ * into a sensor_msgs/Image depth image defined in REP 118 - depth images.
+ * The Image has a canonical format (z-values in Meters, float 1-channel image(TYPE_32FC1))
+ */
+sensor_msgs::ImagePtr depthImageFromNxLibNode(NxLibItem const& node, std::string const& frame);

--- a/ensenso_camera/scripts/request_data
+++ b/ensenso_camera/scripts/request_data
@@ -17,6 +17,7 @@ def main():
     goal.request_raw_images = rospy.get_param("~raw_images", True)
     goal.request_rectified_images = rospy.get_param("~rectified_images", True)
     goal.request_disparity_map = rospy.get_param("~disparity_map", True)
+    goal.request_depth_image = rospy.get_param("~depth_image", True)
     goal.request_point_cloud = rospy.get_param("~point_cloud", True)
     goal.request_normals = rospy.get_param("~normals", True)
 

--- a/ensenso_camera_msgs/action/RequestData.action
+++ b/ensenso_camera_msgs/action/RequestData.action
@@ -6,6 +6,7 @@ string parameter_set
 bool request_raw_images
 bool request_rectified_images
 bool request_disparity_map
+bool request_depth_image
 bool request_point_cloud
 bool request_normals
 
@@ -31,6 +32,9 @@ sensor_msgs/PointCloud2 point_cloud
 
 # The disparity map as it is represented in the NxLib.
 sensor_msgs/Image disparity_map
+
+# The rectified depth image
+sensor_msgs/Image depth_image
 
 # The raw images of the left and right camera respectively. A single image if
 # FlexView is disabled.

--- a/ensenso_camera_test/test/request_data.test
+++ b/ensenso_camera_test/test/request_data.test
@@ -30,5 +30,8 @@
 	<test pkg="rostest" type="hztest" test-name="point_cloud_test">
       <param name="topic" value="point_cloud"/>
 	</test>
+	<test pkg="rostest" type="hztest" test-name="depth_image_test">
+      <param name="topic" value="depth/image"/>
+    </test>
   </group>
 </launch>


### PR DESCRIPTION
depth image as described in http://www.ros.org/reps/rep-0118.html. This image message has the canonical form (z-values in meters).