### PR TITLE
Initial Travis config based on industrial_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+
+services:
+  - docker
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true
+
+env:
+  global:
+    - CCACHE_DIR=$HOME/.ccache
+    - ROS_REPO=main
+  matrix:
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" ROS_REPO=testing
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" ROS_REPO=testing
+
+install:
+  - git clone -b master --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+
+script:
+  - .industrial_ci/travis.sh


### PR DESCRIPTION
This is a bare-bones `industrial_ci` setup for Travis CI.

It will fail, as the Ensenso SDK is not installed yet, but this shows how to set something like this up.

Feel free to add commits to add the SDK, or ignore and do something different.

The terseness of this can't be beat though imo (a testament to @ipa-mdl's work).
