### PR TITLE
Added optional capture timeout parameter for stereo camera

### DIFF
--- a/ensenso_camera/include/ensenso_camera/stereo_camera.h
+++ b/ensenso_camera/include/ensenso_camera/stereo_camera.h
@@ -66,9 +66,13 @@ private:
   std::string handEyeCalibrationPatternBuffer;
   std::vector<tf2::Transform> handEyeCalibrationRobotPoses;
 
+  // Timeout, in milliseconds, used for capture commands. If <= 0, default timeout is used.
+  int captureTimeout;
+
 public:
   StereoCamera(ros::NodeHandle nh, std::string serial, std::string fileCameraPath, bool fixed, std::string cameraFrame,
-               std::string targetFrame, std::string robotFrame, std::string wristFrame, std::string linkFrame);
+               std::string targetFrame, std::string robotFrame, std::string wristFrame, std::string linkFrame,
+               int captureTimeout);
 
   bool open() override;
 

--- a/ensenso_camera/src/nodelet.cpp
+++ b/ensenso_camera/src/nodelet.cpp
@@ -115,8 +115,11 @@ void Nodelet::onInit()
     linkFrame = cameraFrame;
   }
 
+  int captureTimeout;
+  nhLocal.param("capture_timeout", captureTimeout, 0);
+
   camera = make_unique<StereoCamera>(nh, serial, fileCameraPath, cameraIsFixed, cameraFrame, targetFrame, robotFrame,
-                                     wristFrame, linkFrame);
+                                     wristFrame, linkFrame, captureTimeout);
   if (!camera->open())
   {
     NODELET_ERROR("Failed to open the camera. Shutting down.");

--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -14,11 +14,12 @@
 
 StereoCamera::StereoCamera(ros::NodeHandle nh, std::string serial, std::string fileCameraPath, bool fixed,
                            std::string cameraFrame, std::string targetFrame, std::string robotFrame,
-                           std::string wristFrame, std::string linkFrame)
+                           std::string wristFrame, std::string linkFrame, int captureTimeout)
   : Camera(nh, std::move(serial), std::move(fileCameraPath), fixed, std::move(cameraFrame), std::move(targetFrame),
            std::move(linkFrame))
   , robotFrame(std::move(robotFrame))
   , wristFrame(std::move(wristFrame))
+  , captureTimeout(captureTimeout)
 {
   leftCameraInfo = boost::make_shared<sensor_msgs::CameraInfo>();
   rightCameraInfo = boost::make_shared<sensor_msgs::CameraInfo>();
@@ -1143,6 +1144,10 @@ ros::Time StereoCamera::capture() const
 
   NxLibCommand capture(cmdCapture, serial);
   capture.parameters()[itmCameras] = serial;
+  if (captureTimeout > 0)
+  {
+    capture.parameters()[itmTimeout] = captureTimeout;
+  }
   capture.execute();
 
   NxLibItem imageNode = cameraNode[itmImages][itmRaw];


### PR DESCRIPTION
# Problem

When using a virtual stereo camera, I am experiencing timeouts during captures. The solution I've used is to set the *timeout* property on the capture command.

# Solution

Added an optional ROS node/nodelet argument `capture_timeout`. If set to a value greater than 0, this explicit timeout is used in the capture command. If less than or equal to 0, it is ignored. Defaults to 0.

I've only tested this locally with a virtual camera, and it is working OK.