### PR TITLE
WIP: Made the library compile on windows with Visual Studio

### DIFF
--- a/ensenso_camera/CMakeLists.txt
+++ b/ensenso_camera/CMakeLists.txt
@@ -3,7 +3,13 @@ project(ensenso_camera)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+
+if(UNIX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+endif()
+if(WIN32)
+  add_definitions("-DWIN32_LEAN_AND_MEAN")
+endif()
 
 find_package(Boost 1.58.0 REQUIRED)
 find_package(OpenCV REQUIRED)

--- a/ensenso_camera/include/ensenso_camera/queued_action_server.h
+++ b/ensenso_camera/include/ensenso_camera/queued_action_server.h
@@ -34,7 +34,7 @@ public:
                      bool autoStart = false)
     : nodeHandle(nodeHandle), callback(callback)
   {
-    actionServer = make_unique<actionlib::ActionServer<ActionSpec>>(nodeHandle, name, false);
+    actionServer = ::make_unique<actionlib::ActionServer<ActionSpec>>(nodeHandle, name, false);
     actionServer->registerGoalCallback(boost::bind(&QueuedActionServer::onGoalReceived, this, _1));
     actionServer->registerCancelCallback(boost::bind(&QueuedActionServer::onCancelReceived, this, _1));
 

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -29,13 +29,13 @@ Camera::Camera(ros::NodeHandle const& n, std::string serial, std::string fileCam
 
   isFileCamera = !this->fileCameraPath.empty();
 
-  accessTreeServer = make_unique<AccessTreeServer>(nh, "access_tree", boost::bind(&Camera::onAccessTree, this, _1));
+  accessTreeServer = ::make_unique<AccessTreeServer>(nh, "access_tree", boost::bind(&Camera::onAccessTree, this, _1));
   executeCommandServer =
-      make_unique<ExecuteCommandServer>(nh, "execute_command", boost::bind(&Camera::onExecuteCommand, this, _1));
+      ::make_unique<ExecuteCommandServer>(nh, "execute_command", boost::bind(&Camera::onExecuteCommand, this, _1));
   getParameterServer =
-      make_unique<GetParameterServer>(nh, "get_parameter", boost::bind(&Camera::onGetParameter, this, _1));
+      ::make_unique<GetParameterServer>(nh, "get_parameter", boost::bind(&Camera::onGetParameter, this, _1));
   setParameterServer =
-      make_unique<SetParameterServer>(nh, "set_parameter", boost::bind(&Camera::onSetParameter, this, _1));
+      ::make_unique<SetParameterServer>(nh, "set_parameter", boost::bind(&Camera::onSetParameter, this, _1));
 
   statusPublisher = nh.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
 

--- a/ensenso_camera/src/mono_camera.cpp
+++ b/ensenso_camera/src/mono_camera.cpp
@@ -12,9 +12,9 @@ MonoCamera::MonoCamera(ros::NodeHandle nh, std::string serial, std::string fileC
   rectifiedCameraInfo = boost::make_shared<sensor_msgs::CameraInfo>();
 
   requestDataServer =
-      make_unique<RequestDataMonoServer>(nh, "request_data", boost::bind(&MonoCamera::onRequestData, this, _1));
+      ::make_unique<RequestDataMonoServer>(nh, "request_data", boost::bind(&MonoCamera::onRequestData, this, _1));
   locatePatternServer =
-      make_unique<LocatePatternMonoServer>(nh, "locate_pattern", boost::bind(&MonoCamera::onLocatePattern, this, _1));
+      ::make_unique<LocatePatternMonoServer>(nh, "locate_pattern", boost::bind(&MonoCamera::onLocatePattern, this, _1));
 
   image_transport::ImageTransport imageTransport(nh);
   rawImagePublisher = imageTransport.advertiseCamera("raw/image", 1);

--- a/ensenso_camera/src/nodelet.cpp
+++ b/ensenso_camera/src/nodelet.cpp
@@ -118,7 +118,7 @@ void Nodelet::onInit()
   int captureTimeout;
   nhLocal.param("capture_timeout", captureTimeout, 0);
 
-  camera = make_unique<StereoCamera>(nh, serial, fileCameraPath, cameraIsFixed, cameraFrame, targetFrame, robotFrame,
+  camera = ::make_unique<StereoCamera>(nh, serial, fileCameraPath, cameraIsFixed, cameraFrame, targetFrame, robotFrame,
                                      wristFrame, linkFrame, captureTimeout);
   if (!camera->open())
   {

--- a/ensenso_camera/src/nodelet_mono.cpp
+++ b/ensenso_camera/src/nodelet_mono.cpp
@@ -125,7 +125,7 @@ void NodeletMono::onInit()
     linkFrame = cameraFrame;
   }
 
-  camera = make_unique<MonoCamera>(nh, serial, fileCameraPath, cameraIsFixed, cameraFrame, targetFrame, linkFrame);
+  camera = ::make_unique<MonoCamera>(nh, serial, fileCameraPath, cameraIsFixed, cameraFrame, targetFrame, linkFrame);
   if (!camera->open())
   {
     NODELET_ERROR("Failed to open the camera. Shutting down.");

--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -27,23 +27,23 @@ StereoCamera::StereoCamera(ros::NodeHandle nh, std::string serial, std::string f
   rightRectifiedCameraInfo = boost::make_shared<sensor_msgs::CameraInfo>();
 
   fitPrimitiveServer =
-      make_unique<FitPrimitiveServer>(nh, "fit_primitive", boost::bind(&StereoCamera::onFitPrimitive, this, _1));
+      ::make_unique<FitPrimitiveServer>(nh, "fit_primitive", boost::bind(&StereoCamera::onFitPrimitive, this, _1));
   setParameterServer =
-      make_unique<SetParameterServer>(nh, "set_parameter", boost::bind(&StereoCamera::onSetParameter, this, _1));
+      ::make_unique<SetParameterServer>(nh, "set_parameter", boost::bind(&StereoCamera::onSetParameter, this, _1));
 
   requestDataServer =
-      make_unique<RequestDataServer>(nh, "request_data", boost::bind(&StereoCamera::onRequestData, this, _1));
+      ::make_unique<RequestDataServer>(nh, "request_data", boost::bind(&StereoCamera::onRequestData, this, _1));
   locatePatternServer =
-      make_unique<LocatePatternServer>(nh, "locate_pattern", boost::bind(&StereoCamera::onLocatePattern, this, _1));
+      ::make_unique<LocatePatternServer>(nh, "locate_pattern", boost::bind(&StereoCamera::onLocatePattern, this, _1));
   projectPatternServer =
-      make_unique<ProjectPatternServer>(nh, "project_pattern", boost::bind(&StereoCamera::onProjectPattern, this, _1));
-  calibrateHandEyeServer = make_unique<CalibrateHandEyeServer>(
+      ::make_unique<ProjectPatternServer>(nh, "project_pattern", boost::bind(&StereoCamera::onProjectPattern, this, _1));
+  calibrateHandEyeServer = ::make_unique<CalibrateHandEyeServer>(
       nh, "calibrate_hand_eye", boost::bind(&StereoCamera::onCalibrateHandEye, this, _1));
-  calibrateWorkspaceServer = make_unique<CalibrateWorkspaceServer>(
+  calibrateWorkspaceServer = ::make_unique<CalibrateWorkspaceServer>(
       nh, "calibrate_workspace", boost::bind(&StereoCamera::onCalibrateWorkspace, this, _1));
-  telecentricProjectionServer = make_unique<TelecentricProjectionServer>(
+  telecentricProjectionServer = ::make_unique<TelecentricProjectionServer>(
       nh, "project_telecentric", boost::bind(&StereoCamera::onTelecentricProjection, this, _1));
-  texturedPointCloudServer = make_unique<TexturedPointCloudServer>(
+  texturedPointCloudServer = ::make_unique<TexturedPointCloudServer>(
       nh, "texture_point_cloud", boost::bind(&StereoCamera::onTexturedPointCloud, this, _1));
 
   image_transport::ImageTransport imageTransport(nh);
@@ -1043,12 +1043,12 @@ void StereoCamera::onTexturedPointCloud(ensenso_camera_msgs::TexturedPointCloudG
     return;
   }
 
-  double far = goal->far_plane ? goal->far_plane : 10000.;
-  double near = goal->near_plane ? goal->near_plane : -10000.;
+  double farPlane = goal->far_plane ? goal->far_plane : 10000.;
+  double nearPlane = goal->near_plane ? goal->near_plane : -10000.;
   bool useOpenGL = goal->use_opengl == 1;
   bool withTexture = true;
 
-  RenderPointMapParamsProjection params(useOpenGL, far, near, withTexture);
+  RenderPointMapParamsProjection params(useOpenGL, farPlane, nearPlane, withTexture);
 
   NxLibCommand renderPointMap(cmdRenderPointMap, serial);
   for (int i = 0; i < static_cast<int>(goal->serials.size()); i++)


### PR DESCRIPTION
Fixed several build errors when compiling with MSVC on Windows.

I've tested this, and both the node and nodelets are working after building them with MSVC 2017 Professional on Windows 10.

**Note: I'm not sure if this is the best way to fix these issues, but I'm simply posting this here for you to see and decide if we should continue with a preliminary windows support or not.**

# Changes

* The custom `make_unique` clashes with `std::make_unique`. I just did a quick fix by prefixing all uses of `make_unique` with `::`.
* Added `-DDWIN32_LEAN_AND_MEAN` compile definition on Windows
* Removed use of `near` and `far` as variable names (see [Compiler error when using “near” as a variable name](https://stackoverflow.com/questions/22848825/compiler-error-when-using-near-as-a-variable-name/22848865#22848865)).
* Removed unknown compiler flag `-pedantic`
* Removed the `-Wall` flag to avoid a large number of warnings -- at least until they are fixed.

# Remaining issues on MSVC

* The Ensenso SDK does not (as far as I can tell) come with a `FindEnsenso.cmake` of Windows, as it does for Linux. However, I simply made my own and put it in my Ensenso install folder, using the Linux-one as a template.