### PR TITLE
WIP: Added support for virtual objects

### DIFF
--- a/ensenso_camera/CMakeLists.txt
+++ b/ensenso_camera/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(
   src/image_utilities.cpp
   src/point_cloud_utilities.cpp
   src/pose_utilities.cpp
+  src/virtual_object_handler.cpp
 )
 target_link_libraries(
   ensenso_camera_nodelet

--- a/ensenso_camera/include/ensenso_camera/stereo_camera.h
+++ b/ensenso_camera/include/ensenso_camera/stereo_camera.h
@@ -2,6 +2,8 @@
 
 #include "ensenso_camera/camera.h"
 
+#include <ensenso_camera/virtual_object_handler.h>
+
 #include <ensenso_camera_msgs/RequestDataAction.h>
 #include <ensenso_camera_msgs/LocatePatternAction.h>
 #include <ensenso_camera_msgs/ProjectPatternAction.h>
@@ -69,10 +71,14 @@ private:
   // Timeout, in milliseconds, used for capture commands. If <= 0, default timeout is used.
   int captureTimeout;
 
+  // Handler for virtual objects.
+  // If set, will update the 'Objects' item based on the current pose of the camera, before each capture.
+  std::unique_ptr<ensenso_camera::VirtualObjectHandler> virtualObjectHandler;
+
 public:
   StereoCamera(ros::NodeHandle nh, std::string serial, std::string fileCameraPath, bool fixed, std::string cameraFrame,
                std::string targetFrame, std::string robotFrame, std::string wristFrame, std::string linkFrame,
-               int captureTimeout);
+               int captureTimeout, std::unique_ptr<ensenso_camera::VirtualObjectHandler> virtualObjectHandler=nullptr);
 
   bool open() override;
 

--- a/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
+++ b/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
@@ -1,0 +1,23 @@
+#include <vector>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2/LinearMath/Transform.h>
+
+namespace ensenso_camera {
+    class VirtualObjectHandler {
+    public:
+        VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame);
+
+        void updateObjectLinks();
+
+    private:
+        /// Original object poses in the base frame
+        std::vector<tf2::Transform> originalPoses;
+
+        std::string objectsFrame;    ///< Frame in which objects are defined
+        std::string cameraFrame;     ///< Optical frame of the camera
+
+        tf2_ros::Buffer tfBuffer;
+        tf2_ros::TransformListener tfListener{ tfBuffer };
+    };
+}

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -1,0 +1,72 @@
+#include <ensenso_camera/virtual_object_handler.h>
+
+#include <ensenso_camera/pose_utilities.h>
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <nxLib.h>
+
+
+using namespace ensenso_camera;
+
+namespace {
+    std::string readFile(const std::string &filename)
+    {
+        std::ifstream file{ filename };
+        if (!file.is_open() || !file.rdbuf()) {
+            throw std::runtime_error("Unable to read objects file");
+        }
+
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        return buffer.str();
+    }
+}
+
+VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame) :
+    objectsFrame(objectsFrame),
+    cameraFrame(cameraFrame)
+{
+    nxLibInitialize(false);
+
+    // Read the file contents and assign it to the objects tag
+    auto objects = NxLibItem{ itmObjects };
+    objects.setJson(readFile(filename));
+
+    // Get the original poses from file
+    for (int i = 0; i < objects.count(); ++i) {
+        originalPoses.push_back(poseFromNxLib(objects[i][itmLink]));
+    }
+}
+
+void VirtualObjectHandler::updateObjectLinks() {
+    // Exit early if we have no work to do
+    if (originalPoses.empty())
+    {
+        return;
+    }
+
+    // Find transform from the frame in which the objects were defined to the current optical frame
+    tf2::Transform cameraPose;
+    try
+    {
+        cameraPose = fromMsg(tfBuffer.lookupTransform(cameraFrame, objectsFrame, ros::Time(0)).transform);
+    }
+    catch (const tf2::TransformException& e)
+    {
+        ROS_WARN("Could not look up the virtual object pose due to the TF error: %s", e.what());
+        return;
+    }
+
+    // Apply the transform to all of the original poses
+    for (size_t i = 0; i < originalPoses.size(); ++i)
+    {
+        tf2::Transform objectPose = cameraPose * originalPoses[i];
+        NxLibItem objectLink = NxLibItem{ itmObjects }[static_cast<int>(i)][itmLink];
+        writePoseToNxLib(objectPose.inverse(), objectLink);
+    }
+}


### PR DESCRIPTION
Added support for writing virtual objects to the *Objects* `nxLibItem`. This is used for virtual cameras.

**Note: I'm not sure if this is the best way to implement this, but I'm posting this here for you to see and decide what you think is the best way forward.**

# How it works

* You specify the an initial *Objects* item as the path to a JSON file.
* You specify the frame in which the objects in this file is defined.
* For each capture, the objects are transformed into the camera space, using tf2.
* The capture then continues as normal. For virtual cameras, you will see the virtual objects.

# Screenshots

This is just an illustration to show that I can see the objects. I have here mounted the camera to a virtual robot, and when I move the robot, I see the virtual objects correctly. With this, I'm able to create a full virtual clone of a robot and camera.

![image](https://user-images.githubusercontent.com/2614828/72225847-64bba700-358a-11ea-9e31-7db99e9c0460.png)![image](https://user-images.githubusercontent.com/2614828/72225856-7bfa9480-358a-11ea-8af5-8ebd4e63fd32.png)

![image](https://user-images.githubusercontent.com/2614828/72225818-1e664800-358a-11ea-8808-e0de4736e4cc.png)

# Remains to be tested

* Non-identity hand-eye calibration.
