### PR TITLE
Fixed sporadic bug in hand-eye calibration where feedback was attempted before progress was available

### DIFF
--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -808,10 +808,13 @@ void StereoCamera::onCalibrateHandEye(ensenso_camera_msgs::CalibrateHandEyeGoalC
     ros::Rate waitingRate(5);
     while (!calibrateHandEye.finished())
     {
-      ensenso_camera_msgs::CalibrateHandEyeFeedback feedback;
-      feedback.number_of_iterations = calibrateHandEye.result()[itmProgress][itmIterations].asInt();
-      feedback.residual = getCalibrationResidual(calibrateHandEye.result()[itmProgress]);
-      calibrateHandEyeServer->publishFeedback(feedback);
+      if (calibrateHandEye.result()[itmProgress].exists())
+      {
+        ensenso_camera_msgs::CalibrateHandEyeFeedback feedback;
+        feedback.number_of_iterations = calibrateHandEye.result()[itmProgress][itmIterations].asInt();
+        feedback.residual = getCalibrationResidual(calibrateHandEye.result()[itmProgress]);
+        calibrateHandEyeServer->publishFeedback(feedback);
+      }
 
       if (calibrateHandEyeServer->isPreemptRequested())
       {


### PR DESCRIPTION

I noticed a sporadic crash because the *Progress* node did not exist during hand-eye calibration. This was with a virtual camera.

# Cause

During hand-eye calibration, the following code is executed

```cpp
NxLibCommand calibrateHandEye(cmdCalibrateHandEye, serial);
calibrateHandEye.execute(false);
while (!calibrateHandEye.finished()) {
    ensenso_camera_msgs::CalibrateHandEyeFeedback feedback;
    feedback.number_of_iterations = calibrateHandEye.result()[itmProgress][itmIterations].asInt();
    feedback.residual = getCalibrationResidual(calibrateHandEye.result()[itmProgress]);
    calibrateHandEyeServer->publishFeedback(feedback);
}
```

I concluded that this must be because of a race condition, in which the main thread is reading the *Progress* node created by a worker thread. Printing the contents of `calibrateHandEye.result()` reveals that the *Progress* node is not created until some time has passed:

```
[ INFO] [1579082632.274600800]: progress: {
        "Time": 2.2157,
        "TimeExecute": 0.432599999999999651,
        "TimeFinalize": 0.0316999999999998394,
        "TimePrepare": 1.24019999999999997
}
[ INFO] [1579082632.775791000]: progress: {
        "Progress": {
                "Iterations": 11,
                "Residual": 0.0903454391874089907
        },
        "Time": 404.227700000000027,
        "TimeExecute": 0,
        "TimeFinalize": 0.129799999999928806,
        "TimePrepare": 0.317699999999999982
}
```

# Fix

I stopped sending feedback until the *Progress* node is created. The action is still preemtable as before.

# Setup

* Windows 10
* Virtual N35 camera
