### PR TITLE
Fixed a crash where targetFrame was identical to linkedFrame

### DIFF
--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -271,7 +271,7 @@ void Camera::updateGlobalLink(ros::Time time, std::string frame, bool useCachedT
   // of the NxLib. When the target frame is different from the camera's own
   // frame, we set the camera's link target to this link node.
 
-  if (cameraFrame == frame)
+  if (cameraFrame == frame || linkFrame == frame)
   {
     // The camera frame is the target frame already. No need to transform
     // anything in the NxLib.
@@ -282,27 +282,22 @@ void Camera::updateGlobalLink(ros::Time time, std::string frame, bool useCachedT
   cameraNode[itmLink][itmTarget] = TARGET_FRAME_LINK + "_" + serial;
 
   // Update the transformation to the target frame in the NxLib according to
-  // the current information from TF. Only if the link frame and target frame differs. Otherwise the transformation will
-  // be doubled. If they're the same, the global Link must be the identity transform and the tf will be in the camera
-  // link. (camera -> link in Nxlib or link -> camera in ROS).
-  if (frame != linkFrame)
+  // the current information from TF. Only if the link frame and target frame differs.
+  geometry_msgs::TransformStamped transform;
+  if (useCachedTransformation && transformationCache.count(frame) != 0)
   {
-    geometry_msgs::TransformStamped transform;
-    if (useCachedTransformation && transformationCache.count(frame) != 0)
-    {
-      transform = transformationCache[frame];
-    }
-    else
-    {
-      transform = tfBuffer.lookupTransform(linkFrame, frame, time, ros::Duration(TRANSFORMATION_REQUEST_TIMEOUT));
-      transformationCache[frame] = transform;
-    }
-    tf2::Transform tfTrafo;
-    tf2::convert(transform.transform, tfTrafo);
-    NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial].setNull();
-    NxLibItem()[itmLinks].setNull();
-    writePoseToNxLib(tfTrafo, NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial]);
+    transform = transformationCache[frame];
   }
+  else
+  {
+    transform = tfBuffer.lookupTransform(linkFrame, frame, time, ros::Duration(TRANSFORMATION_REQUEST_TIMEOUT));
+    transformationCache[frame] = transform;
+  }
+  tf2::Transform tfTrafo;
+  tf2::convert(transform.transform, tfTrafo);
+  NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial].setNull();
+  NxLibItem()[itmLinks].setNull();
+  writePoseToNxLib(tfTrafo, NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial]);
 }
 
 std::vector<geometry_msgs::TransformStamped> Camera::estimatePatternPoses(ros::Time imageTimestamp,


### PR DESCRIPTION
I observed a crash when setting `target_frame` to `link_frame`. Looking through the implementation in [camera.cpp (line259-306)](https://github.com/ensenso/ros_driver/blob/a3d836be93eb12c68bd743085cdce66d4445f4a0/ensenso_camera/src/camera.cpp#L259-L306) we have the following

```cpp
void Camera::updateGlobalLink(/*...snip...*/) const
{
  // ...snip...

  if (cameraFrame == frame)
  {
    // The camera frame is the target frame already. No need to transform
    // anything in the NxLib.
    cameraNode[itmLink][itmTarget] = "";
    return;
  }

  cameraNode[itmLink][itmTarget] = TARGET_FRAME_LINK + "_" + serial;

  if (frame != linkFrame)
  {
    // ...snip...
    NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial].setNull();
    NxLibItem()[itmLinks].setNull();
    writePoseToNxLib(tfTrafo, NxLibItem()[itmLinks][TARGET_FRAME_LINK + "_" + serial]);
  }
```

From what I can reason, when `frame == linkFrame`, the link target is set to `Worksapce_<serial>`, but `Workspace_<serial>` is never created.

The fix I propose in this changeset is quite trivial:

```cpp
void Camera::updateGlobalLink(/*...snip...*/) const
{
  // ...snip...

  if (cameraFrame == frame || linkFrame == frame)
  {
    // The camera frame is the target frame already. No need to transform
    // anything in the NxLib.
    cameraNode[itmLink][itmTarget] = "";
    return;
  }
```

The reasoning here is that when `linkFrame == targetFrame`, then the link in `cameraNode[itmLink]` is enough.