### PR TITLE
Fixed compilation on ROS noetic

### DIFF
--- a/ensenso_camera/CMakeLists.txt
+++ b/ensenso_camera/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ensenso_camera)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if("$ENV{ROS_DISTRO}" STREQUAL "noetic")
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+else()
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 if(UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")


### PR DESCRIPTION
PCL on noetic (version 1.9.1 I believe) requires C++14.

I haven't tested tested with an actual camera, but at least it builds (with `colcon build`).

To be conservative, I only enabled C++14 on noetic specifically. I guess it should also have worked on melodic, but I don't know if there is a point in doing that.