### PR TITLE
Added optional publishing of virtual objects

### DIFF
--- a/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
+++ b/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
@@ -8,7 +8,7 @@
 namespace ensenso_camera {
     class VirtualObjectHandler {
     public:
-        VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame,
+        VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &linkFrame,
                              const std::string &markerTopic, double markerPublishRate);
         ~VirtualObjectHandler();
 
@@ -22,7 +22,7 @@ namespace ensenso_camera {
         std::vector<tf2::Transform> originalPoses;
 
         std::string objectsFrame;    ///< Frame in which objects are defined
-        std::string cameraFrame;     ///< Optical frame of the camera
+        std::string linkFrame;       ///< Link frame where NxLib expects the objects to be defined
 
         tf2_ros::Buffer tfBuffer;
         tf2_ros::TransformListener tfListener{ tfBuffer };

--- a/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
+++ b/ensenso_camera/include/ensenso_camera/virtual_object_handler.h
@@ -1,3 +1,5 @@
+#include <atomic>
+#include <thread>
 #include <vector>
 
 #include <tf2_ros/transform_listener.h>
@@ -6,11 +8,16 @@
 namespace ensenso_camera {
     class VirtualObjectHandler {
     public:
-        VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame);
+        VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame,
+                             const std::string &markerTopic, double markerPublishRate);
+        ~VirtualObjectHandler();
 
         void updateObjectLinks();
 
     private:
+        std::thread markerThread; ///< Background thread used to publish object markers
+        std::atomic_bool stopMarkerThread{false}; ///< Flag to indicate markerThread should stop
+
         /// Original object poses in the base frame
         std::vector<tf2::Transform> originalPoses;
 

--- a/ensenso_camera/src/nodelet.cpp
+++ b/ensenso_camera/src/nodelet.cpp
@@ -129,10 +129,18 @@ void Nodelet::onInit()
     std::string objectsFrame = targetFrame;
     nhLocal.getParam("objects_frame", objectsFrame);
 
+    // Get virtual object marker publish settings.
+    // Default to empty topic, meaning no markers are published.
+    std::string markerTopic;
+    double markerRate = 1;
+    nhLocal.getParam("visualization_marker_topic", markerTopic);
+    nhLocal.getParam("visualization_marker_rate", markerRate);
+
     NODELET_DEBUG("Loading virtual objects...");
     try
     {
-      virtualObjectHandler = ::make_unique<VirtualObjectHandler>(objectsFile, objectsFrame, cameraFrame);
+      virtualObjectHandler = ::make_unique<VirtualObjectHandler>(objectsFile, objectsFrame, cameraFrame,
+                                                                 markerTopic, markerRate);
     }
     catch (const std::exception &e)
     {

--- a/ensenso_camera/src/nodelet.cpp
+++ b/ensenso_camera/src/nodelet.cpp
@@ -139,7 +139,7 @@ void Nodelet::onInit()
     NODELET_DEBUG("Loading virtual objects...");
     try
     {
-      virtualObjectHandler = ::make_unique<VirtualObjectHandler>(objectsFile, objectsFrame, cameraFrame,
+      virtualObjectHandler = ::make_unique<VirtualObjectHandler>(objectsFile, objectsFrame, linkFrame,
                                                                  markerTopic, markerRate);
     }
     catch (const std::exception &e)

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -8,6 +8,8 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 
+#include <visualization_msgs/MarkerArray.h>
+
 #include <nxLib.h>
 
 
@@ -25,9 +27,119 @@ namespace {
         buffer << file.rdbuf();
         return buffer.str();
     }
+
+    /// Class responsible for publishing NxLib virtual objects as ROS visualization_msgs::MarkerArray
+    struct VirtualObjectMarkerPublisher
+    {
+      VirtualObjectMarkerPublisher(const std::string &topic, double publishRate, const NxLibItem& objects,
+                                   const std::string &frame, std::atomic_bool& stop_)
+        : rate(publishRate), stop(stop_)
+      {
+        // Create output topic
+        ros::NodeHandle node;
+        publisher = node.advertise<visualization_msgs::MarkerArray>(topic, 1);
+
+        // Collect markers
+        for (int i = 0; i < objects.count(); ++i)
+        {
+          auto& object = objects[i];
+          auto type = object[itmType];
+
+          visualization_msgs::Marker marker;
+          marker.ns = ros::this_node::getName();
+          marker.id = i;
+          marker.header.stamp = ros::Time::now();
+          marker.header.frame_id = frame;
+          marker.action = visualization_msgs::Marker::MODIFY;  // Note: ADD = MODIFY
+
+          // Set color
+          const auto color = object[itmLighting][itmColor];
+          if (color.exists() && color.count() == 3)
+          {
+            marker.color.r = color[0].asDouble();
+            marker.color.g = color[1].asDouble();
+            marker.color.b = color[2].asDouble();
+            marker.color.a = 1.0;
+          }
+          else
+          {
+            // Default color (gray)
+            marker.color.r = 0.5;
+            marker.color.g = 0.5;
+            marker.color.b = 0.5;
+            marker.color.a = 1.0;
+          }
+
+          // Set pose
+          marker.pose = poseFromTransform(poseFromNxLib(object[itmLink]));
+
+          // Set type and deal with object-specific properties
+          if (type.asString() == valSphere)
+          {
+            marker.type = visualization_msgs::Marker::SPHERE;
+
+            // Sphere scale is diameter in meters
+            marker.scale.x = object[itmRadius].asDouble() * 2.0 / 1000.0;
+            marker.scale.y = marker.scale.x;
+            marker.scale.z = marker.scale.x;
+          }
+          else if (type.asString() == valCylinder)
+          {
+            marker.type = visualization_msgs::Marker::CYLINDER;
+
+            /// Cylinder scale x/y is diameter in meters, z is height in meters.
+            marker.scale.x = object[itmRadius].asDouble() * 2.0 / 1000.0;
+            marker.scale.y = marker.scale.x;
+            marker.scale.z = object[itmHeight].asDouble() / 1000.0;
+
+            /// Cylinders in NxLib start at the base.
+            /// Cylinders in ROS start at the centroid.
+            // marker.pose.position.z += marker.scale.z / 2.0;
+          }
+          else if (type.asString() == valCube)
+          {
+            marker.type = visualization_msgs::Marker::CUBE;
+
+            marker.scale.x = object[itmWidth].asDouble() / 1000.0;
+            marker.scale.y = object[itmWidth].asDouble() / 1000.0;
+            marker.scale.z = object[itmWidth].asDouble() / 1000.0;
+          }
+          else if (type.asString() == valCuboid)
+          {
+            marker.type = visualization_msgs::Marker::CUBE;
+
+            marker.scale.x = object[itmWidth].asDouble() / 1000.0;
+            marker.scale.z = object[itmHeight].asDouble() / 1000.0;
+            marker.scale.y = object[itmDepth].asDouble() / 1000.0;
+          }
+          else
+          {
+            // Unsupported type, skip it
+            continue;
+          }
+
+          markers.markers.push_back(marker);
+        }
+      }
+
+      void run()
+      {
+        while (ros::ok() && !stop)
+        {
+          publisher.publish(markers);
+          rate.sleep();
+        }
+      }
+
+      ros::Publisher publisher;
+      ros::Rate rate;
+      visualization_msgs::MarkerArray markers;
+      std::atomic_bool& stop;
+    };
 }
 
-VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame) :
+VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame,
+                                           const std::string &markerTopic, double markerPublishRate) :
     objectsFrame(objectsFrame),
     cameraFrame(cameraFrame)
 {
@@ -41,6 +153,18 @@ VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const st
     for (int i = 0; i < objects.count(); ++i) {
         originalPoses.push_back(poseFromNxLib(objects[i][itmLink]));
     }
+
+    // Create publisher thread
+    if (!markerTopic.empty()) {
+      markerThread = std::thread([=](){
+        VirtualObjectMarkerPublisher publisher{markerTopic, markerPublishRate, objects, objectsFrame, stopMarkerThread};
+        publisher.run();
+      });
+    }
+}
+
+VirtualObjectHandler::~VirtualObjectHandler() {
+  stopMarkerThread = true;
 }
 
 void VirtualObjectHandler::updateObjectLinks() {

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -43,7 +43,6 @@ namespace {
         for (int i = 0; i < objects.count(); ++i)
         {
           auto& object = objects[i];
-          auto type = object[itmType];
 
           visualization_msgs::Marker marker;
           marker.ns = ros::this_node::getName();
@@ -73,8 +72,21 @@ namespace {
           // Set pose
           marker.pose = poseFromTransform(poseFromNxLib(object[itmLink]));
 
+          auto type = object[itmType];
+          auto filename = object[itmFilename];
+
           // Set type and deal with object-specific properties
-          if (type.asString() == valSphere)
+          if (filename.exists())
+          {
+            marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+            marker.mesh_resource = "file://" + filename.asString();
+
+            // Scale from mm to m
+            marker.scale.x = 1.0 / 1000.0;
+            marker.scale.y = 1.0 / 1000.0;
+            marker.scale.z = 1.0 / 1000.0;
+          }
+          else if (type.asString() == valSphere)
           {
             marker.type = visualization_msgs::Marker::SPHERE;
 

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -54,10 +54,10 @@ namespace {
           const auto color = object[itmLighting][itmColor];
           if (color.exists() && color.count() == 3)
           {
-            marker.color.r = color[0].asDouble();
-            marker.color.g = color[1].asDouble();
-            marker.color.b = color[2].asDouble();
-            marker.color.a = 1.0;
+            marker.color.r = static_cast<float>(color[0].asDouble());
+            marker.color.g = static_cast<float>(color[1].asDouble());
+            marker.color.b = static_cast<float>(color[2].asDouble());
+            marker.color.a = 1.0f;
           }
           else
           {

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -138,10 +138,10 @@ namespace {
     };
 }
 
-VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &cameraFrame,
+VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const std::string &objectsFrame, const std::string &linkFrame,
                                            const std::string &markerTopic, double markerPublishRate) :
     objectsFrame(objectsFrame),
-    cameraFrame(cameraFrame)
+    linkFrame(linkFrame)
 {
     nxLibInitialize(false);
 
@@ -178,7 +178,7 @@ void VirtualObjectHandler::updateObjectLinks() {
     tf2::Transform cameraPose;
     try
     {
-        cameraPose = fromMsg(tfBuffer.lookupTransform(cameraFrame, objectsFrame, ros::Time(0)).transform);
+        cameraPose = fromMsg(tfBuffer.lookupTransform(linkFrame, objectsFrame, ros::Time(0)).transform);
     }
     catch (const tf2::TransformException& e)
     {

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -36,8 +36,7 @@ namespace {
         : rate(publishRate), stop(stop_)
       {
         // Create output topic
-        ros::NodeHandle node;
-        publisher = node.advertise<visualization_msgs::MarkerArray>(topic, 1);
+        publisher = m_node_handle.advertise<visualization_msgs::MarkerArray>(topic, 1);
 
         // Collect markers
         for (int i = 0; i < objects.count(); ++i)
@@ -143,6 +142,7 @@ namespace {
         }
       }
 
+      ros::NodeHandle m_node_handle;
       ros::Publisher publisher;
       ros::Rate rate;
       visualization_msgs::MarkerArray markers;

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -177,6 +177,11 @@ VirtualObjectHandler::VirtualObjectHandler(const std::string &filename, const st
 
 VirtualObjectHandler::~VirtualObjectHandler() {
   stopMarkerThread = true;
+
+  if (markerThread.joinable())
+  {
+    markerThread.join();
+  }
 }
 
 void VirtualObjectHandler::updateObjectLinks() {


### PR DESCRIPTION
The virtual objects are now (optionally) published as ROS `visualization_msgs::MarkerArray`.

You enable this by specifying the `visualization_marker_topic` parameter. This way, you can view the virtual objects inside RViz, which makes it quite

Supported types as of now are:

* Cylinder
* Sphere
* Cube
* Cuboid

Features I may work on in the future:

- Going the other way - taking `visualization_msgs::MarkerArray` as input to virtual objects
- Mesh/STL support

Tested on ROS Noetic on Ubuntu.

Here are some screenshots from my development:

![enenso1](https://user-images.githubusercontent.com/2614828/97234943-24a87680-17e2-11eb-909f-44bf6a966c76.png)
![enesnso2](https://user-images.githubusercontent.com/2614828/97234945-26723a00-17e2-11eb-8a8f-b25d2a4fea89.png)