### PR TITLE
Convert depth image units from millimeters to meters

### DIFF
--- a/ensenso_camera/src/image_utilities.cpp
+++ b/ensenso_camera/src/image_utilities.cpp
@@ -173,6 +173,9 @@ sensor_msgs::ImagePtr depthImageFromNxLibNode(NxLibItem const& node, std::string
   cv::Mat depthImage;
   cv::extractChannel(pointMap, depthImage, 2);
 
+  // convert units from millimeters to meters
+  depthImage /= 1000.0;
+
   // convert cv mat to ros image
   cv_bridge::CvImage out_msg;
   out_msg.header.stamp.fromSec(timestamp - NXLIB_TIMESTAMP_OFFSET);

--- a/ensenso_camera_test/test/telecentric_projection.py
+++ b/ensenso_camera_test/test/telecentric_projection.py
@@ -93,8 +93,8 @@ class TestTelecentricProjection(unittest.TestCase):
         # Message to cv image
         cv_image = bridge.imgmsg_to_cv2(image, desired_encoding="passthrough")
 
-        # Convert it to a mono image via numpy
-        mono8 = np.uint8(cv_image)
+        # Convert it to a mono image (expressed in millimeters) via numpy
+        mono8 = np.uint8(cv_image * 1000.0)
         cv.imwrite(PATH + "/image/mono8.jpg", mono8)
 
         # Grey image to binary image


### PR DESCRIPTION
## Summary
This PR should fix the issue described in #60; depth images seem to be expressed in millimeters whereas the [ROS standard](https://www.ros.org/reps/rep-0118.html) requires that floating point images be expressed in meters. To fix that we just divide the images by `1000.0` just before they're converted into Image messages.

## How To Test
Follow the `Viewing Your First Point Cloud` in RViz tutorial on the wiki
```
$ rosrun ensenso_camera ensenso_camera_node
$ rosrun ensenso_camera request_data
```
Choose a pixel in one of the images published to `/depth/image` and make sure that its value corresponds to the distance in meters between whatever that ray is pointing at and the camera.

## Note:
Unfortunately I actually don't have access to a camera until later in the week so I can't say for sure that these changes fix the issue. If someone on your side can test these changes that'd be much appreciated otherwise I can do so later in the week / early next week