### PR TITLE
Update camera info timestamp when publishing depth images

### DIFF
--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -354,6 +354,7 @@ void StereoCamera::onRequestData(ensenso_camera_msgs::RequestDataGoalConstPtr co
       if (cameraFrame == targetFrame)
       {
         auto depthImage = depthImageFromNxLibNode(cameraNode[itmImages][itmPointMap], targetFrame);
+        leftRectifiedCameraInfo->header.stamp = depthImage->header.stamp;
 
         if (goal->include_results_in_response)
         {


### PR DESCRIPTION
## Summary

This should fix the problem described in #59.  When requesting data, if the depth image is requested but rectified images aren't, the timestamp field of the depth image's camera info won't be filled in. This PR fixes that by filling in the camera info timestamp using the stamp of the depth image just prior to it being published.

## How To Test
* Request some data from the ensenso with `goal.request_depth_image` set to `True` and `goal.request_rectified_images` set to `False`
* Check that the timestamp field in `/depth/camera_info` matches the timestamp in the header of the depth image that was published at the same time.

## Note
As I mentioned in the other PR, I don't have access to a physical camera at the moment. This change seems really straightforward so I'm confident it'll do the trick but if you guys wouldn't mind testing this change before this is merged that'd be much appreciated.