### PR TITLE
Add support for XR-Series

### DIFF
--- a/ensenso_camera/include/ensenso_camera/stereo_camera.h
+++ b/ensenso_camera/include/ensenso_camera/stereo_camera.h
@@ -36,6 +36,8 @@ private:
   sensor_msgs::CameraInfoPtr rightCameraInfo;
   sensor_msgs::CameraInfoPtr leftRectifiedCameraInfo;
   sensor_msgs::CameraInfoPtr rightRectifiedCameraInfo;
+  sensor_msgs::CameraInfoPtr disparityMapCameraInfo;
+  sensor_msgs::CameraInfoPtr depthImageCameraInfo;
 
   std::unique_ptr<RequestDataServer> requestDataServer;
   std::unique_ptr<CalibrateHandEyeServer> calibrateHandEyeServer;
@@ -50,7 +52,7 @@ private:
   image_transport::CameraPublisher rightRawImagePublisher;
   image_transport::CameraPublisher leftRectifiedImagePublisher;
   image_transport::CameraPublisher rightRectifiedImagePublisher;
-  image_transport::Publisher disparityMapPublisher;
+  image_transport::CameraPublisher disparityMapPublisher;
   image_transport::CameraPublisher depthImagePublisher;
   image_transport::Publisher projectedImagePublisher;
 
@@ -147,6 +149,12 @@ private:
   void loadParameterSet(std::string name, ProjectorState projector = projectorDontCare);
 
   /**
+   * Grab the timestamp of the last captured (raw) image. Handle the different image sources across different camera
+   * models (file camera, S-Series, XR-Series or normal stereo camera).
+   */
+  ros::Time timestampOfCapturedImage() const;
+
+  /**
    * Try to collect patterns on the current images. For the command to be successful, the patterns must be decodable and
    * visible in both cameras.
    */
@@ -166,12 +174,32 @@ private:
   bool isSSeries() const;
 
   /**
+   * Return whether this camera is an XR-Series camera.
+   */
+  bool isXrSeries() const;
+
+  /**
    * Return whether this camera has a right camera sensor.
    */
   bool hasRightCamera() const;
 
   /**
+   * Return whether this cameras has/stores raw images.
+   */
+  bool hasRawImages() const;
+
+  /**
+   * Return whether this camera downloads the raw/rectified images.
+   */
+  bool hasDownloadedImages() const;
+
+  /**
    * Return whether this camera has a disparity map.
    */
   bool hasDisparityMap() const;
+
+  /**
+   * Add the NxLib internal disparity map offset to the given camera info.
+   */
+  void addDisparityMapOffset(sensor_msgs::CameraInfoPtr const& info) const;
 };

--- a/ensenso_camera/include/ensenso_camera/stereo_camera.h
+++ b/ensenso_camera/include/ensenso_camera/stereo_camera.h
@@ -36,7 +36,6 @@ private:
   sensor_msgs::CameraInfoPtr rightCameraInfo;
   sensor_msgs::CameraInfoPtr leftRectifiedCameraInfo;
   sensor_msgs::CameraInfoPtr rightRectifiedCameraInfo;
-  sensor_msgs::CameraInfoPtr disparityMapCameraInfo;
   sensor_msgs::CameraInfoPtr depthImageCameraInfo;
 
   std::unique_ptr<RequestDataServer> requestDataServer;

--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -1525,7 +1525,7 @@ bool StereoCamera::hasRightCamera() const
 bool StereoCamera::hasRawImages() const
 {
   std::string captureMode = cameraNode[itmParameters][itmCapture][itmMode].asString();
-  return captureMode == "Raw";
+  return captureMode == valRaw;
 }
 
 bool StereoCamera::hasDownloadedImages() const

--- a/ensenso_camera_msgs/action/RequestData.action
+++ b/ensenso_camera_msgs/action/RequestData.action
@@ -33,9 +33,11 @@ sensor_msgs/PointCloud2 point_cloud
 
 # The disparity map as it is represented in the NxLib.
 sensor_msgs/Image disparity_map
+sensor_msgs/CameraInfo disparity_map_info
 
-# The rectified depth image
+# The rectified depth image.
 sensor_msgs/Image depth_image
+sensor_msgs/CameraInfo depth_image_info
 
 # The raw images of the left and right camera respectively. A single image if
 # FlexView is disabled.


### PR DESCRIPTION
Ich habe beim Aufräumen den `s-series` Branch gelöscht und damit wurde #72 automatisch geschlossen, da der Merge sich auf diesen Branch bezogen hatte; deshalb der neue PR.

`leftRectifiedCameraInfo` und `depthImageCameraInfo` haben den selben Inhalt, daher können wir in `addDisparityMapOffset()` einfach den Disparity Offset von `width` und `cx` abziehen.

Die 4 Commits sollten noch gesquashed werden bevor wir den Branch mergen.