### PR TITLE
feat: added option to wait for camera on startup

### DIFF
--- a/ensenso_camera/include/ensenso_camera/camera.h
+++ b/ensenso_camera/include/ensenso_camera/camera.h
@@ -195,6 +195,11 @@ struct CameraParameters
   bool fixed;
 
   /**
+   * Whether the node should wait for the camera to become available
+   */
+  bool wait_for_camera = false;
+
+  /**
    * The tf frame in which the data is captured by the camera.
    */
   std::string cameraFrame;

--- a/ensenso_camera/launch/mono_stereo_nodelets.launch
+++ b/ensenso_camera/launch/mono_stereo_nodelets.launch
@@ -4,16 +4,20 @@
   <arg name="stereo_ns" doc="Namespace for the stereo camera" />
   <arg name="mono_ns" doc="Namespace for the mono camera" />
   <arg name="target_frame_name" value="Workspace" doc="The root the tf tree"/>
+  <arg name="wait_for_camera" doc="whether the node should wait for the camera to become available" />
 
   <node pkg="nodelet" type="nodelet" name="manager_"  args="manager" output="screen" />
   <!-- Camera nodes running as nodelets -->
   <node pkg="nodelet" type="nodelet" name="Ensenso_$(arg serial_stereo)" args="load ensenso_camera/stereo_camera_nodelet /manager_" output="screen" ns="$(arg stereo_ns)">
     <param name="serial" type="string" value="$(arg serial_stereo)" />
     <param name="target_frame" type="string" value="$(arg target_frame_name)" />
+    <param name="wait_for_camera" type="bool" value="$(arg wait_for_camera)" />
+
   </node>
 
   <node pkg="nodelet" type="nodelet" name="Ensenso_$(arg serial_mono)" args="load ensenso_camera/mono_camera_nodelet /manager_" output="screen" ns="$(arg mono_ns)">
     <param name="serial" type="string" value="$(arg serial_mono)" />
     <param name="link_frame" value="$(arg serial_stereo)_optical_frame" />
+    <param name="wait_for_camera" type="bool" value="$(arg wait_for_camera)" />
   </node>
 </launch>

--- a/ensenso_camera/launch/nodelet.launch
+++ b/ensenso_camera/launch/nodelet.launch
@@ -1,10 +1,13 @@
 <launch>
   <arg name="camera" value="150580" />
   <arg name="target_frame" value="Workspace" />
+  <arg name="wait_for_camera" doc="whether the node should wait for the camera to become available" />
+
 
   <node pkg="nodelet" type="nodelet" name="manager_"  args="manager" output="screen" />
   <node pkg="nodelet" type="nodelet" name="Ensenso_$(arg camera)" args="load ensenso_camera/stereo_camera_nodelet /manager_" output="screen">
     <param name="serial" type="string" value="$(arg camera)" />
     <param name="target_frame" type="string" value="$(arg target_frame)" />
+    <param name="wait_for_camera" type="bool" value="$(arg wait_for_camera)" />
   </node>
 </launch>

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -22,6 +22,7 @@ CameraParameters::CameraParameters(ros::NodeHandle const& nh, std::string const&
   isFileCamera = !fileCameraPath.empty();
 
   nh.param("fixed", fixed, false);
+  nh.param("wait_for_camera", wait_for_camera, false);
 
   if (!nh.getParam("camera_frame", cameraFrame))
   {
@@ -514,7 +515,16 @@ bool Camera::open()
     ROS_ERROR("The camera '%s' could not be found", params.serial.c_str());
     return false;
   }
-  if (!cameraIsAvailable())
+
+  if (params.wait_for_camera)
+  {
+    while (!cameraIsAvailable() && ros::ok())
+    {
+      ROS_INFO("Waiting for camera '%s' to become available", params.serial.c_str());
+      ros::Duration(0.5).sleep();
+    }
+  }
+  else if (!cameraIsAvailable())
   {
     ROS_ERROR("The camera '%s' is already in use", params.serial.c_str());
     return false;


### PR DESCRIPTION
Small feature that makes it possible to wait for a camera to become available at startup of the nodelet.

I added a new parameter `wait_for_camera` that defaults to false so the current behaviour will not change.  If set to `True` the nodelet will wait in an endless loop until the camera becomes available or the node shuts down.

Typically a camera stays in use for up to 30 seconds after the camera node or NxView is shutdown. This feature enables us to automatically restart the camera driver without having to worry about the camera to be in use at start up.