### PR TITLE
fix: always initialize transform in getCameraToLinkTransform

### DIFF
--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -652,8 +652,10 @@ geometry_msgs::TransformStamped Camera::stampedLinkToCamera()
 
 tf2::Transform Camera::getCameraToLinkTransform()
 {
-  // The NxLib will always give the transfrom from the camera to the link target in camera coordinates.
-  tf2::Transform transform;
+  // The NxLib will always give the transform from the camera to the link target in camera coordinates.
+  // Always initialize transform otherwise the transform will be invalid
+  tf2::Transform transform = tf2::Transform::getIdentity();
+
   try
   {
     transform = poseFromNxLib(cameraNode[itmLink]);
@@ -666,7 +668,6 @@ tf2::Transform Camera::getCameraToLinkTransform()
 
   if (!isValid(transform))
   {
-    transform.setIdentity();
     ROS_WARN("Did not find a good transform from %s to %s. Transform has been set to identity",
              params.cameraFrame.c_str(), params.linkFrame.c_str());
   }


### PR DESCRIPTION
This MR fixes a edge case in which the transform returned by `getCameraToLinkTransform` was not set to a valid transform if an NxLib execption occurred. 

It does this by always setting the transform to a identity transform at the beginning for the function. 

An alternative to this solution would be to actually do what the error message in the catch section says, and not publish the transform at al.
```
Link does not exists.Therefore we cannot publish a transform to any target. 
```
But that would require more refactoring

