### PR TITLE
fix: start status timer for mono camera

### DIFF
--- a/ensenso_camera/src/mono_camera.cpp
+++ b/ensenso_camera/src/mono_camera.cpp
@@ -27,6 +27,7 @@ void MonoCamera::init()
   advertiseTopics();
   startServers();
   initTfPublishTimer();
+  initStatusTimer();
 }
 
 void MonoCamera::startServers() const


### PR DESCRIPTION
This MR enables the publishing of the camera status on the `/diagnostics` topic by calling `initStatusTimer` in the `MonoCamera::init()` . That way the status of the mono camera can also be tracked