### PR TITLE
Fix overwriting of parameter sets when opening multiple cameras

### DIFF
--- a/ensenso_camera/include/ensenso_camera/camera.h
+++ b/ensenso_camera/include/ensenso_camera/camera.h
@@ -12,6 +12,7 @@
 #include "ensenso_camera/nxlib_version.h"
 #include "ensenso_camera/point_cloud_utilities.h"
 #include "ensenso_camera/queued_action_server.h"
+#include "ensenso_camera/string_helper.h"
 #include "ensenso_camera/virtual_object_handler.h"
 
 #include "nxLib.h"

--- a/ensenso_camera/include/ensenso_camera/string_helper.h
+++ b/ensenso_camera/include/ensenso_camera/string_helper.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdlib.h>
+
+inline bool startswith(std::string const& lhs, std::string const& rhs)
+{
+  return lhs.rfind(rhs, 0) == 0;
+}
+
+inline std::string expandPath(std::string const& path_)
+{
+  std::string path(path_);
+  if (startswith(path, "~/"))
+  {
+    path = getenv("HOME") + std::string("/") + path.substr(2, std::string::npos);
+  }
+  return path;
+}

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -114,9 +114,11 @@ void Camera::startServers() const
 bool Camera::loadSettings(const std::string& jsonFile, bool saveAsDefaultParameters)
 {
   if (jsonFile.empty())
+  {
     return true;
+  }
 
-  std::ifstream file(jsonFile);
+  std::ifstream file(expandPath(jsonFile));
   if (file.is_open() && file.rdbuf())
   {
     std::stringstream buffer;
@@ -154,7 +156,11 @@ bool Camera::loadSettings(const std::string& jsonFile, bool saveAsDefaultParamet
 
       updateCameraInfo();
       if (saveAsDefaultParameters)
+      {
         saveDefaultParameterSet();
+      }
+
+      ROS_INFO("Loaded settings from '%s'.", jsonFile.c_str());
     }
     catch (NxLibException& e)
     {

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -99,7 +99,7 @@ Camera::Camera(ros::NodeHandle& nh, CameraParameters _params) : params(std::move
   nxLibVersion.fillFromNxLib();
 
   cameraNode = NxLibItem()[itmCameras][itmBySerialNo][params.serial];
-  defaultParameters = NxLibItem()["rosDefaultParameters"];
+  defaultParameters = NxLibItem()["rosDefaultParameters"][params.serial + "_" + DEFAULT_PARAMETER_SET];
 }
 
 void Camera::startServers() const

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -638,7 +638,8 @@ void Camera::loadParameterSet(std::string name)
   if (parameterSets.count(name) == 0)
   {
     // The parameter set was never used before. Create it by copying the default settings.
-    parameterSets.insert(std::make_pair(name, ParameterSet(name, defaultParameters)));
+    std::string nodeName = params.serial + "_" + name;
+    parameterSets.insert(std::make_pair(name, ParameterSet(nodeName, defaultParameters)));
   }
 
   ParameterSet const& parameterSet = parameterSets.at(name);

--- a/ensenso_camera/src/mono_camera.cpp
+++ b/ensenso_camera/src/mono_camera.cpp
@@ -197,6 +197,11 @@ void MonoCamera::onSetParameter(ensenso_camera_msgs::SetParameterGoalConstPtr co
     }
   }
 
+  for (auto const& parameter : goal->parameters)
+  {
+    writeParameter(parameter);
+  }
+
   // Synchronize to make sure that we read back the correct values.
   NxLibCommand synchronize(cmdSynchronize, params.serial);
   synchronize.parameters()[itmCameras] = params.serial;
@@ -204,7 +209,7 @@ void MonoCamera::onSetParameter(ensenso_camera_msgs::SetParameterGoalConstPtr co
 
   saveParameterSet(goal->parameter_set);
 
-  // Calibration could have changed after setting new parameters
+  // Calibration could have changed after setting new parameters.
   updateCameraInfo();
 
   // Read back the actual values.

--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -1508,11 +1508,6 @@ void StereoCamera::writeParameter(ensenso_camera_msgs::Parameter const& paramete
   }
 }
 
-bool startswith(std::string const& lhs, std::string const& rhs)
-{
-  return lhs.rfind(rhs, 0) == 0;
-}
-
 bool StereoCamera::isSSeries() const
 {
   return cameraNode[itmType].asString() == "StructuredLight";


### PR DESCRIPTION
Ich hab noch eine Funktion eingebaut, die es uns ermöglicht auch Datei-Pfade beginnend mit `~/` zu akzeptieren. Bislang ist der Knoten da einfach abgestürzt mit der Fehlermeldung, dass er die Datei nicht finden kann.