### PR TITLE
CI: Bump tested Ensenso SDK to the latest version of the 3.3 branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,13 +51,13 @@ jobs:
         os: [ubuntu-22.04]
         ros_distro: [humble]
         ros_version: [2]
-        ensenso_sdk_version: [3.3.1385, 3.2.489, 3.1.996]
+        ensenso_sdk_version: [3.3.1417, 3.2.489, 3.1.996]
         include:
         # Ubuntu 20.04 - foxy
           - os: ubuntu-20.04
             ros_distro: foxy
             ros_version: 2
-            ensenso_sdk_version: 3.3.1385
+            ensenso_sdk_version: 3.3.1417
           - os: ubuntu-20.04
             ros_distro: foxy
             ros_version: 2
@@ -70,7 +70,7 @@ jobs:
           - os: ubuntu-20.04
             ros_distro: noetic
             ros_version: 1
-            ensenso_sdk_version: 3.3.1385
+            ensenso_sdk_version: 3.3.1417
           - os: ubuntu-20.04
             ros_distro: noetic
             ros_version: 1
@@ -83,7 +83,7 @@ jobs:
           - os: ubuntu-18.04
             ros_distro: melodic
             ros_version: 1
-            ensenso_sdk_version: 3.3.1385
+            ensenso_sdk_version: 3.3.1417
           - os: ubuntu-18.04
             ros_distro: melodic
             ros_version: 1


### PR DESCRIPTION
Die beiden Commits, in denen jeweils die SDK Versionen im Workflow geändert wurde, haben dafür gesorgt, dass der PR alte Workflow-Runs erwartet, deren SDK Versionen aber gar nicht mehr Teil des Workflow sein sollten.

Deshalb hab ich die Commits jetzt auseinander gezogen damit man sie einzeln mergen kann.