### PR TITLE
Fixed undefined behavior in VirtualObjectMarkerPublisher

### DIFF
--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -176,8 +176,9 @@ VirtualObjectHandler::VirtualObjectHandler(ensenso::ros::NodeHandle& nh, const s
   // Create publisher thread
   if (!markerTopic.empty())
   {
-    markerThread = std::thread([&]() {
-      VirtualObjectMarkerPublisher publisher{ nh,      markerTopic,  markerPublishRate,
+    auto nh_ptr = &nh;
+    markerThread = std::thread([=]() {
+      VirtualObjectMarkerPublisher publisher{ *nh_ptr, markerTopic,  markerPublishRate,
                                               objects, objectsFrame, stopMarkerThread };
       publisher.run();
     });


### PR DESCRIPTION
The input arguments were captured by reference, then used in a thread. It could happen that by the time the thread started, the references were invalidated.

Fixed by capturing by value instead.