### PR TITLE
Fix virtual objects

### DIFF
--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -38,9 +38,9 @@ std::string readFile(const std::string& filename)
 /// Class responsible for publishing NxLib virtual objects as ROS visualization_msgs::MarkerArray
 struct VirtualObjectMarkerPublisher
 {
-  VirtualObjectMarkerPublisher(ensenso::ros::NodeHandle& nh, const std::string& topic, double publishRate,
+  VirtualObjectMarkerPublisher(ensenso::ros::NodeHandle _nh, const std::string& topic, double publishRate,
                                const NxLibItem& objects, const std::string& frame, std::atomic_bool& stop_)
-    : nh(nh), rate(publishRate), stop(stop_)
+    : nh(std::move(_nh)), rate(publishRate), stop(stop_)
   {
     // Create output topic
     publisher = ensenso::ros::create_publisher<visualization_msgs::msg::MarkerArray>(nh, topic, 1);
@@ -176,7 +176,7 @@ VirtualObjectHandler::VirtualObjectHandler(ensenso::ros::NodeHandle& nh, const s
   // Create publisher thread
   if (!markerTopic.empty())
   {
-    markerThread = std::thread([&]() {
+    markerThread = std::thread([=]() {
       VirtualObjectMarkerPublisher publisher{ nh,      markerTopic,  markerPublishRate,
                                               objects, objectsFrame, stopMarkerThread };
       publisher.run();

--- a/ensenso_camera/src/virtual_object_handler.cpp
+++ b/ensenso_camera/src/virtual_object_handler.cpp
@@ -54,7 +54,7 @@ struct VirtualObjectMarkerPublisher
 
       marker.ns = ensenso::ros::get_node_name(nh);
       marker.id = i;
-      marker.header.stamp = ensenso::ros::now(nh);
+      marker.header.stamp = ensenso::ros::Time(0);
       marker.header.frame_id = frame;
       marker.action = visualization_msgs::msg::Marker::MODIFY;  // Note: ADD = MODIFY
 


### PR DESCRIPTION
- Covers @jornb, @benthie fix on #102.
- Second commit fixes time stamp of virtual objects. 
  - When having moving object frame, tf2 complains with the following error:
``
Error looking up robot pose: Lookup would require extrapolation into the past
``
  