### PR TITLE
stereo_camera: Fix usage of automatically adjusted parameters

### DIFF
--- a/ensenso_camera/src/stereo_camera.cpp
+++ b/ensenso_camera/src/stereo_camera.cpp
@@ -276,6 +276,10 @@ void StereoCamera::onRequestData(ensenso::action::RequestDataGoalConstPtr const&
   loadParameterSet(goal->parameter_set, computeDisparityMap ? projectorOn : projectorOff);
   ensenso::ros::Time imageTimestamp = capture();
 
+  // Auto values like auto exposure might have changed. Save the parameters so that the updated values are used when
+  // capturing the next time.
+  saveParameterSet(goal->parameter_set, false);
+
   PREEMPT_ACTION_IF_REQUESTED
 
   feedback.images_acquired = true;


### PR DESCRIPTION
For example, if auto exposure was enabled, the value calculated by the NxLib was not updated in the parameter set. This had the effect that the original start value was re-used when capturing the next time, and it took several frames again to obtain a good result.

Save the parameter set after capture to update the automatically adjusted values.