### PR TITLE
CI: Test Ensenso SDK 4.2.1765

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,47 +51,47 @@ jobs:
         os: [ubuntu-24.04]
         ros_distro: [jazzy]
         ros_version: [2]
-        ensenso_sdk_version: [4.1.1033, 4.0.1526, 3.6.1631]
+        ensenso_sdk_version: [4.2.1765, 4.1.1033, 4.0.1526]
         include:
         # Ubuntu 22.04 - humble
           - os: ubuntu-22.04
             ros_distro: humble
             ros_version: 2
+            ensenso_sdk_version: 4.2.1765
+          - os: ubuntu-22.04
+            ros_distro: humble
+            ros_version: 2
             ensenso_sdk_version: 4.1.1033
           - os: ubuntu-22.04
             ros_distro: humble
             ros_version: 2
             ensenso_sdk_version: 4.0.1526
-          - os: ubuntu-22.04
-            ros_distro: humble
-            ros_version: 2
-            ensenso_sdk_version: 3.6.1631
         # Ubuntu 20.04 - foxy
           - os: ubuntu-20.04
             ros_distro: foxy
             ros_version: 2
+            ensenso_sdk_version: 4.2.1765
+          - os: ubuntu-20.04
+            ros_distro: foxy
+            ros_version: 2
             ensenso_sdk_version: 4.1.1033
           - os: ubuntu-20.04
             ros_distro: foxy
             ros_version: 2
             ensenso_sdk_version: 4.0.1526
-          - os: ubuntu-20.04
-            ros_distro: foxy
-            ros_version: 2
-            ensenso_sdk_version: 3.6.1631
         # Ubuntu 20.04 - noetic
           - os: ubuntu-20.04
             ros_distro: noetic
             ros_version: 1
+            ensenso_sdk_version: 4.2.1765
+          - os: ubuntu-20.04
+            ros_distro: noetic
+            ros_version: 1
             ensenso_sdk_version: 4.1.1033
           - os: ubuntu-20.04
             ros_distro: noetic
             ros_version: 1
             ensenso_sdk_version: 4.0.1526
-          - os: ubuntu-20.04
-            ros_distro: noetic
-            ros_version: 1
-            ensenso_sdk_version: 3.6.1631
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Replaces the test with SDKs from the 3.6 branch.